### PR TITLE
Fix space sign disagreement

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -660,8 +660,8 @@ class AssistantToTargetTranslator:
             # If the assistant tokenizer has a different space sign than the target tokenizer,
             # we need to replace the assistant space sign with the target space sign in the assistant_vocab.
             assistant_vocab = {
-                (k.replace(assistant_space_sign, target_space_sign, 1) if k.startswith(assistant_space_sign) else k): v
-                for k, v in assistant_vocab.items()
+                (tok.replace(assistant_space_sign, target_space_sign, 1) if tok.startswith(assistant_space_sign) else tok): idx
+                for tok, idx in assistant_vocab.items()
             }
         
         max_assistant_index = max(assistant_vocab.values())

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -627,15 +627,18 @@ class AssistantToTargetTranslator:
         self,
         target_tokenizer: "PreTrainedTokenizerBase",
         assistant_tokenizer: "PreTrainedTokenizerBase",
-        assistant_model_device,
-        target_vocab_size: int,
+        assistant_model_device:str = "cpu",
+        target_vocab_size: int = None,
         filter_value: float = -float("Inf"),
         suppress_tokens_id: int = -1,
     ):
         self._target_tokenizer: "PreTrainedTokenizerBase" = target_tokenizer
         self._assistant_tokenizer: "PreTrainedTokenizerBase" = assistant_tokenizer
-        self._assistant_model_device = assistant_model_device
-        self.target_vocab_size: int = target_vocab_size
+        self._assistant_model_device:str = assistant_model_device
+        if target_vocab_size:
+            self.target_vocab_size: int = target_vocab_size
+        else:
+            self.target_vocab_size: int = len(self._target_tokenizer.get_vocab())
         self.filter_value: float = filter_value
         self.suppress_tokens_id: int = suppress_tokens_id
         self._assistant_to_target_input_ids = self._get_assistant_to_target_input_ids()
@@ -707,8 +710,8 @@ class AssistantVocabTranslatorCache:
         cls,
         target_tokenizer: "PreTrainedTokenizerBase",
         assistant_tokenizer: "PreTrainedTokenizerBase",
-        assistant_model_device,
-        target_vocab_size: int,
+        assistant_model_device: str = "cpu",
+        target_vocab_size: int = None,
     ) -> AssistantToTargetTranslator:
         with cls._lock:
             assistant_dict = cls._cache.get(target_tokenizer)

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -627,14 +627,14 @@ class AssistantToTargetTranslator:
         self,
         target_tokenizer: "PreTrainedTokenizerBase",
         assistant_tokenizer: "PreTrainedTokenizerBase",
-        assistant_model_device:str = "cpu",
+        assistant_model_device: str = "cpu",
         target_vocab_size: int = None,
         filter_value: float = -float("Inf"),
         suppress_tokens_id: int = -1,
     ):
         self._target_tokenizer: "PreTrainedTokenizerBase" = target_tokenizer
         self._assistant_tokenizer: "PreTrainedTokenizerBase" = assistant_tokenizer
-        self._assistant_model_device:str = assistant_model_device
+        self._assistant_model_device: str = assistant_model_device
         if target_vocab_size:
             self.target_vocab_size: int = target_vocab_size
         else:
@@ -650,20 +650,27 @@ class AssistantToTargetTranslator:
         target_vocab = self._target_tokenizer.get_vocab()
         assistant_vocab = self._assistant_tokenizer.get_vocab()
 
-        target_space_ids = self._target_tokenizer(" ", add_special_tokens=False)["input_ids"]
-        target_space_sign = self._target_tokenizer.convert_ids_to_tokens(target_space_ids)[0][0]
+        space_str = " "
+        target_space_ids = self._target_tokenizer(space_str, add_special_tokens=False)["input_ids"]
+        if len(target_space_ids) > 0:
+            target_space_sign = self._target_tokenizer.convert_ids_to_tokens(target_space_ids)[0][0]
 
-        assistant_space_ids = self._assistant_tokenizer(" ", add_special_tokens=False)["input_ids"]
-        assistant_space_sign = self._assistant_tokenizer.convert_ids_to_tokens(assistant_space_ids)[0][0]
+            assistant_space_ids = self._assistant_tokenizer(space_str, add_special_tokens=False)["input_ids"]
+            if len(assistant_space_ids) > 0:
+                assistant_space_sign = self._assistant_tokenizer.convert_ids_to_tokens(assistant_space_ids)[0][0]
 
-        if target_space_sign != assistant_space_sign:
-            # If the assistant tokenizer has a different space sign than the target tokenizer,
-            # we need to replace the assistant space sign with the target space sign in the assistant_vocab.
-            assistant_vocab = {
-                (tok.replace(assistant_space_sign, target_space_sign, 1) if tok.startswith(assistant_space_sign) else tok): idx
-                for tok, idx in assistant_vocab.items()
-            }
-        
+                if target_space_sign != assistant_space_sign:
+                    # If the assistant tokenizer has a different space sign than the target tokenizer,
+                    # we need to replace the assistant space sign with the target space sign in the assistant_vocab.
+                    assistant_vocab = {
+                        (
+                            tok.replace(assistant_space_sign, target_space_sign, 1)
+                            if tok.startswith(assistant_space_sign)
+                            else tok
+                        ): idx
+                        for tok, idx in assistant_vocab.items()
+                    }
+
         max_assistant_index = max(assistant_vocab.values())
         assistant_to_target_input_ids = torch.full((max_assistant_index + 1,), self.suppress_tokens_id, dtype=int)
         for tok, idx in assistant_vocab.items():

--- a/tests/generation/test_candidate_generator.py
+++ b/tests/generation/test_candidate_generator.py
@@ -129,6 +129,12 @@ class MockTokenizer:
     def get_vocab(self):
         return self._vocab
 
+    def __call__(self, text, add_special_tokens=True):
+        # Mock implementation of the __call__ method
+        tokens = text.split()
+        input_ids = [self._vocab.get(token, 0) for token in tokens]
+        return {"input_ids": input_ids}
+
 
 class TestAssistantVocabTranslatorCache(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
In BPE tokenizers, all tokens that occur at the beginning of a word, are stored twice as 'token' and ' token'.
Different tokenizers may use different special characters to represent space and we did not take it into account in `_get_assistant_to_target_input_ids`. Overlap will increase significantly.
The bug has an impact on the target/draft pairs we reported slowdown.