### PR TITLE
Fix: `token_ids.to(torch.int64)`

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -893,7 +893,7 @@ class UniversalSpeculativeDecodingGenerator(AssistedCandidateGeneratorDifferentT
             if tokens_to_remove > 0:
                 self._prev_assistant_ids = self._prev_assistant_ids[:, :-tokens_to_remove]
             assistant_input_ids = torch.cat([self._prev_assistant_ids, assistant_new_ids], dim=-1)
-        assistant_input_ids = assistant_input_ids.to(torch.int64)
+        assistant_input_ids = assistant_input_ids.to(torch.LongTensor)
 
         return assistant_input_ids, len(assistant_new_ids[0])
 


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/35029#discussion_r1931349905 - 
I asked the maintainers to confirm whether `token_ids` should use `torch.int64` (reference: https://huggingface.co/docs/transformers.js/en/api/tokenizers).